### PR TITLE
Remove minimum class price

### DIFF
--- a/src/utils/globals.js
+++ b/src/utils/globals.js
@@ -103,7 +103,7 @@ export const dataMemberToValidation = {
   locationName: () => '',
   locationAddress: () => '',
   price: state =>
-    !Number.isNaN(Number(state.price)) && Number(state.price) >= 10
+    !Number.isNaN(Number(state.price)) && Number(state.price) >= 0
       ? ''
       : 'Invalid price, must be at least $10',
   startDate: state =>


### PR DESCRIPTION
## About

The proper flow for a prepaid event should be to enter a private registration code and then register your children. There should be no need for promo codes because these both cause confusion and create a scenario in which parents could pay for a "free" event. Another issue with using 100% off promo codes is that outside people could still technically register. We could work around this by using both a promo code and registration code, but that would suck for the legitimate customers.